### PR TITLE
feat: Claude Code skill auto-update — minimal consumer skill (#8)

### DIFF
--- a/src/core/skill-generator.test.ts
+++ b/src/core/skill-generator.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest'
+import { generateSkill, generateConsumerSkill } from './skill-generator.js'
+import type { RegistryJson, RegistryEntry, InstalledComponent } from './types.js'
+
+function makeRegistry(overrides: Partial<RegistryJson> = {}): RegistryJson {
+  return {
+    name: 'My Registry',
+    version: '1.0.0',
+    description: 'A test registry',
+    framework: 'react',
+    components: {
+      Button: {
+        name: 'Button',
+        description: 'A button component',
+        category: 'ui',
+        files: ['components/button/index.tsx'],
+        schema: {
+          properties: {
+            variant: { type: 'string', enum: ['primary', 'secondary'], description: 'Button variant' },
+            disabled: { type: 'boolean', description: 'Disable the button' },
+          },
+          required: ['variant'],
+        },
+        dependencies: ['clsx'],
+        examples: [
+          { description: 'Primary button', props: { variant: 'primary' } },
+        ],
+      },
+    },
+    ...overrides,
+  }
+}
+
+function makeRegistries(): RegistryEntry[] {
+  return [
+    { name: 'my-registry', url: 'https://registry.example.com' },
+    { name: 'other-registry', url: 'https://other.example.com' },
+  ]
+}
+
+function makeInstalled(): Record<string, InstalledComponent> {
+  return {
+    Button: { name: 'Button', registry: 'my-registry', version: '1.2.0', files: ['button.tsx'] },
+    Card: { name: 'Card', registry: 'my-registry', files: ['card.tsx'] },
+  }
+}
+
+describe('generateSkill (author-side)', () => {
+  it('includes registry name and description', () => {
+    const registry = makeRegistry()
+    const skill = generateSkill(registry)
+    expect(skill).toContain('My Registry')
+    expect(skill).toContain('A test registry')
+  })
+
+  it('includes component names and props tables', () => {
+    const registry = makeRegistry()
+    const skill = generateSkill(registry)
+    expect(skill).toContain('Button')
+    expect(skill).toContain('variant')
+    expect(skill).toContain('disabled')
+  })
+
+  it('includes examples', () => {
+    const registry = makeRegistry()
+    const skill = generateSkill(registry)
+    expect(skill).toContain('Primary button')
+    expect(skill).toContain('<Button')
+  })
+
+  it('includes overrides when provided', () => {
+    const registry = makeRegistry()
+    const skill = generateSkill(registry, 'Custom composition rules here.')
+    expect(skill).toContain('Custom composition rules here.')
+    expect(skill).toContain('Composition Rules')
+  })
+})
+
+describe('generateConsumerSkill', () => {
+  it('contains the TRIGGER line', () => {
+    const skill = generateConsumerSkill(makeRegistries(), makeInstalled(), 'My Design System', 'Test description')
+    expect(skill).toContain('TRIGGER when:')
+  })
+
+  it('contains blokos CLI discovery commands', () => {
+    const skill = generateConsumerSkill(makeRegistries(), makeInstalled(), 'My Design System', 'Test description')
+    expect(skill).toContain('blokos list --json')
+    expect(skill).toContain('blokos get <name> --json')
+    expect(skill).toContain('blokos search "<query>" --json')
+    expect(skill).toContain('blokos suggest "<phrase>" --json')
+  })
+
+  it('contains blokos CLI install commands', () => {
+    const skill = generateConsumerSkill(makeRegistries(), makeInstalled(), 'My Design System', 'Test description')
+    expect(skill).toContain('blokos add <name>')
+    expect(skill).toContain('blokos update --all')
+    expect(skill).toContain('blokos outdated')
+  })
+
+  it('lists all connected registries with URLs', () => {
+    const skill = generateConsumerSkill(makeRegistries(), makeInstalled(), 'My Design System', 'Test description')
+    expect(skill).toContain('my-registry')
+    expect(skill).toContain('https://registry.example.com')
+    expect(skill).toContain('other-registry')
+    expect(skill).toContain('https://other.example.com')
+  })
+
+  it('lists installed components with count', () => {
+    const skill = generateConsumerSkill(makeRegistries(), makeInstalled(), 'My Design System', 'Test description')
+    expect(skill).toContain('Installed Components (2)')
+    expect(skill).toContain('Button')
+    expect(skill).toContain('Card')
+  })
+
+  it('shows version for components that have it', () => {
+    const skill = generateConsumerSkill(makeRegistries(), makeInstalled(), 'My Design System', 'Test description')
+    expect(skill).toContain('1.2.0')
+  })
+
+  it('shows empty state when no components installed', () => {
+    const skill = generateConsumerSkill(makeRegistries(), {}, 'My Design System', 'Test description')
+    expect(skill).toContain('Installed Components (0)')
+    expect(skill).toContain('blokos add <name>')
+  })
+
+  it('does NOT contain verbose props tables', () => {
+    const skill = generateConsumerSkill(makeRegistries(), makeInstalled(), 'My Design System', 'Test description')
+    // Props tables have this header pattern from generateSkill
+    expect(skill).not.toContain('| Prop | Type | Required | Description |')
+    expect(skill).not.toContain('**Props:**')
+  })
+
+  it('does NOT contain component examples JSX', () => {
+    const skill = generateConsumerSkill(makeRegistries(), makeInstalled(), 'My Design System', 'Test description')
+    // Author skill renders <Button variant="primary" /> style examples
+    expect(skill).not.toContain('<Button')
+  })
+
+  it('includes frontmatter with type: project', () => {
+    const skill = generateConsumerSkill(makeRegistries(), makeInstalled(), 'My Design System', 'Test description')
+    expect(skill).toContain('type: project')
+  })
+
+  it('uses provided registryName and description', () => {
+    const skill = generateConsumerSkill(makeRegistries(), makeInstalled(), 'Acme UI', 'Acme component library.')
+    expect(skill).toContain('Acme UI')
+    expect(skill).toContain('Acme component library.')
+  })
+})

--- a/src/core/skill-generator.ts
+++ b/src/core/skill-generator.ts
@@ -1,5 +1,5 @@
 import fs from 'fs-extra'
-import type { RegistryJson, RegistryComponent } from './types.js'
+import type { RegistryJson, RegistryComponent, RegistryEntry, InstalledComponent } from './types.js'
 
 /**
  * Generate a Claude Code skill markdown from a registry
@@ -118,6 +118,77 @@ function buildExampleJsx(
     .join(' ')
 
   return `<${componentName} ${propsStr} />`
+}
+
+/**
+ * Generate a minimal consumer-side skill that teaches Claude HOW to use the CLI.
+ * Claude fetches component details on-demand via `blokos get <name> --json`.
+ */
+export function generateConsumerSkill(
+  registries: RegistryEntry[],
+  installed: Record<string, InstalledComponent>,
+  registryName: string,
+  description: string
+): string {
+  const lines: string[] = []
+
+  lines.push('---')
+  lines.push(`name: ${registryName} Design System`)
+  lines.push('description: Component library — use blokos CLI to discover and install components')
+  lines.push('type: project')
+  lines.push('---')
+  lines.push('')
+  lines.push(`# ${registryName} — Component Library`)
+  lines.push('')
+  lines.push(description)
+  lines.push('')
+  lines.push('TRIGGER when: user asks to build UI, create a page, or use a component from this design system.')
+  lines.push('')
+  lines.push('## Rules')
+  lines.push('')
+  lines.push('- ONLY use components from this registry. Do NOT invent components.')
+  lines.push('- Run `blokos list --json` first to see what\'s available.')
+  lines.push('- Run `blokos get <name> --json` to get props and examples before using a component.')
+  lines.push('- Run `blokos add <name>` to install a component before importing it.')
+  lines.push('')
+  lines.push('## How to discover')
+  lines.push('')
+  lines.push('```bash')
+  lines.push('blokos list --json              # all available components')
+  lines.push('blokos get <name> --json        # props, examples, dependencies')
+  lines.push('blokos search "<query>" --json  # find by description')
+  lines.push('blokos suggest "<phrase>" --json  # keyword search')
+  lines.push('```')
+  lines.push('')
+  lines.push('## How to install')
+  lines.push('')
+  lines.push('```bash')
+  lines.push('blokos add <name>     # install component + update this skill')
+  lines.push('blokos update --all   # update all installed components')
+  lines.push('blokos outdated       # check for updates')
+  lines.push('```')
+  lines.push('')
+  lines.push('## Connected Registries')
+  lines.push('')
+  for (const reg of registries) {
+    lines.push(`- **${reg.name}**: ${reg.url}`)
+  }
+  lines.push('')
+
+  const installedEntries = Object.values(installed)
+  lines.push(`## Installed Components (${installedEntries.length})`)
+  lines.push('')
+  if (installedEntries.length === 0) {
+    lines.push('_No components installed yet. Run `blokos add <name>` to install one._')
+  } else {
+    for (const comp of installedEntries) {
+      const version = comp.version ? ` @ ${comp.version}` : ''
+      lines.push(`- **${comp.name}**${version} (${comp.registry})`)
+    }
+  }
+  lines.push('')
+
+  return lines.join('\n')
 }
 
 /**

--- a/src/core/skill-updater.ts
+++ b/src/core/skill-updater.ts
@@ -1,11 +1,11 @@
 import fs from 'fs-extra'
 import path from 'node:path'
-import type { ConsumerConfig, RegistryJson } from './types.js'
-import { fetchRegistry, fetchSkill } from './registry-fetcher.js'
-import { generateSkill } from './skill-generator.js'
+import type { ConsumerConfig } from './types.js'
+import { readLockfile } from './lockfile.js'
+import { generateConsumerSkill } from './skill-generator.js'
 
 /**
- * Update local skill files to only include installed components
+ * Update the local consumer-side skill at .claude/skills/blokos-skill.md
  */
 export async function updateLocalSkill(
   cwd: string,
@@ -14,46 +14,31 @@ export async function updateLocalSkill(
   const skillsDir = path.join(cwd, '.claude', 'skills')
   await fs.ensureDir(skillsDir)
 
-  const installedNames = new Set(
-    Object.keys(config.installed || {})
-  )
+  // Use the first registry name/description as the primary identity, or a generic fallback
+  const primaryRegistry = config.registries[0]
+  const registryName = primaryRegistry?.name ?? 'Design System'
+  const description = `Connected to ${config.registries.map((r) => r.name).join(', ')}.`
 
-  for (const reg of config.registries) {
-    try {
-      const registry = await fetchRegistry(reg.url, reg.token)
+  // Read installed components from lockfile for version info
+  const lock = await readLockfile(cwd)
+  const installed = config.installed ?? {}
 
-      // Filter registry to only installed components from this registry
-      const filteredRegistry: RegistryJson = {
-        ...registry,
-        components: {},
-      }
-
-      for (const [name, comp] of Object.entries(registry.components)) {
-        if (installedNames.has(name)) {
-          filteredRegistry.components[name] = comp
-        }
-      }
-
-      if (Object.keys(filteredRegistry.components).length === 0) continue
-
-      // Try fetching overrides from registry skill, or generate fresh
-      let skillContent: string
-
-      if (registry.skill) {
-        try {
-          const fullSkill = await fetchSkill(reg.url, registry.skill, reg.token)
-          skillContent = fullSkill
-        } catch {
-          skillContent = generateSkill(filteredRegistry)
-        }
-      } else {
-        skillContent = generateSkill(filteredRegistry)
-      }
-
-      const skillFileName = `blokos-${reg.name.replace(/[^a-z0-9-]/gi, '-').toLowerCase()}.md`
-      await fs.writeFile(path.join(skillsDir, skillFileName), skillContent)
-    } catch (err) {
-      console.warn(`  Warning: could not update skill for ${reg.name}: ${err}`)
+  // Enrich installed components with version from lockfile
+  const installedWithVersion: typeof installed = {}
+  for (const [name, comp] of Object.entries(installed)) {
+    installedWithVersion[name] = {
+      ...comp,
+      version: lock.components[name]?.version ?? comp.version,
     }
   }
+
+  const skillContent = generateConsumerSkill(
+    config.registries,
+    installedWithVersion,
+    registryName,
+    description
+  )
+
+  const skillFilePath = path.join(skillsDir, 'blokos-skill.md')
+  await fs.writeFile(skillFilePath, skillContent)
 }


### PR DESCRIPTION
## Summary

- Adds generateConsumerSkill() to skill-generator.ts — generates a ~20-line skill that teaches Claude HOW to use the CLI, not WHAT the components are
- Rewrites skill-updater.ts to use generateConsumerSkill(), reads blokos.lock for version data, and writes to the hardcoded path .claude/skills/blokos-skill.md
- blokos add and blokos update already called updateLocalSkill() — they now produce the minimal skill format automatically
- blokos publish continues to generate the verbose author-side skill at skill/blokos-skill.md (no change)
- Adds src/core/skill-generator.test.ts with 15 tests covering both generateSkill (author) and generateConsumerSkill (consumer)

## Test plan

- [x] npm run build — TypeScript compiles cleanly
- [x] npm test — all 73 tests pass (10 test files)
- [x] generateConsumerSkill tests: TRIGGER line, CLI commands, connected registries, installed components list, no verbose props tables, no JSX examples, frontmatter with type: project

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)