### PR TITLE
feat: blokos search / get / suggest — AI-agent-friendly component discovery

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,9 @@ import { listCommand } from './commands/list.js'
 import { outdatedCommand } from './commands/outdated.js'
 import { updateCommand } from './commands/update.js'
 import { tokenCommand } from './commands/token-sync.js'
+import { searchCommand } from './commands/search.js'
+import { getCommand } from './commands/get.js'
+import { suggestCommand } from './commands/suggest.js'
 
 const program = new Command()
 
@@ -25,5 +28,8 @@ program.addCommand(listCommand)
 program.addCommand(outdatedCommand)
 program.addCommand(updateCommand)
 program.addCommand(tokenCommand)
+program.addCommand(searchCommand)
+program.addCommand(getCommand)
+program.addCommand(suggestCommand)
 
 program.parse()

--- a/src/commands/get.ts
+++ b/src/commands/get.ts
@@ -1,0 +1,183 @@
+import { Command } from 'commander'
+import chalk from 'chalk'
+import fs from 'fs-extra'
+import path from 'node:path'
+import { CONSUMER_CONFIG } from '../core/constants.js'
+import { getOrFetchRegistry } from '../core/registry-cache.js'
+import { readLockfile } from '../core/lockfile.js'
+import type { ConsumerConfig, RegistryComponent } from '../core/types.js'
+
+interface ComponentDetail {
+  name: string
+  category: string
+  description: string
+  version: string
+  files: string[]
+  dependencies: string[]
+  examples: Array<{ description: string; props: Record<string, unknown> }>
+  schema: Record<string, unknown>
+  installed: boolean
+  installedVersion: string | undefined
+  registry: string
+}
+
+function printDetail(detail: ComponentDetail): void {
+  const isTTY = process.stdout.isTTY
+
+  if (!isTTY) {
+    console.log(`${detail.name}\t${detail.category}\t${detail.description}`)
+    console.log(`version: ${detail.version}`)
+    console.log(`installed: ${detail.installed ? detail.installedVersion : 'no'}`)
+    console.log(`dependencies: ${detail.dependencies.join(', ') || 'none'}`)
+    console.log(`files: ${detail.files.join(', ')}`)
+    return
+  }
+
+  console.log('')
+  console.log(chalk.bold.cyan(detail.name) + chalk.dim(` (${detail.category})`))
+  console.log(detail.description)
+  console.log('')
+
+  const installStatus = detail.installed
+    ? chalk.green(`✓ installed  v${detail.installedVersion}`) +
+      (detail.installedVersion !== detail.version
+        ? chalk.yellow(`  (latest: v${detail.version})`)
+        : '')
+    : chalk.dim('(not installed)')
+
+  console.log(chalk.bold('Status:     ') + installStatus)
+  console.log(chalk.bold('Registry:   ') + detail.registry)
+  console.log(chalk.bold('Version:    ') + `v${detail.version}`)
+  console.log('')
+
+  if (detail.dependencies.length > 0) {
+    console.log(chalk.bold('Dependencies:'))
+    for (const dep of detail.dependencies) {
+      console.log(`  • ${dep}`)
+    }
+    console.log('')
+  }
+
+  if (detail.files.length > 0) {
+    console.log(chalk.bold('Files:'))
+    for (const file of detail.files) {
+      console.log(`  • ${file}`)
+    }
+    console.log('')
+  }
+
+  // Props schema
+  const props = detail.schema?.properties as Record<string, { type?: string; description?: string }> | undefined
+  if (props && Object.keys(props).length > 0) {
+    console.log(chalk.bold('Props:'))
+    const propNameWidth = Math.max(10, ...Object.keys(props).map((k) => k.length)) + 2
+    const propTypeWidth = 12
+
+    console.log(
+      '  ' +
+        chalk.bold('Name'.padEnd(propNameWidth)) +
+        chalk.bold('Type'.padEnd(propTypeWidth)) +
+        chalk.bold('Description')
+    )
+    console.log('  ' + '─'.repeat(propNameWidth + propTypeWidth + 30))
+
+    for (const [propName, propDef] of Object.entries(props)) {
+      const propType = String(propDef?.type ?? 'unknown')
+      const propDesc = propDef?.description ?? ''
+      console.log(
+        '  ' +
+          propName.padEnd(propNameWidth) +
+          propType.padEnd(propTypeWidth) +
+          chalk.dim(propDesc)
+      )
+    }
+    console.log('')
+  }
+
+  if (detail.examples.length > 0) {
+    console.log(chalk.bold('Examples:'))
+    for (const ex of detail.examples) {
+      console.log(`  ${chalk.dim('—')} ${ex.description}`)
+      console.log('    ' + chalk.dim(JSON.stringify(ex.props)))
+    }
+    console.log('')
+  }
+
+  console.log(`Run ${chalk.cyan(`blokos add ${detail.name}`)} to install.`)
+  console.log('')
+}
+
+export const getCommand = new Command('get')
+  .description('Get full details of a component')
+  .argument('<name>', 'Component name')
+  .option('--json', 'Output as JSON')
+  .option('--no-fetch', 'Skip remote refresh, use cached registry only')
+  .action(async (name: string, opts: { json?: boolean; fetch: boolean }) => {
+    const cwd = process.cwd()
+    const configPath = path.join(cwd, CONSUMER_CONFIG)
+
+    if (!(await fs.pathExists(configPath))) {
+      if (opts.json) {
+        console.log(JSON.stringify({ error: `No ${CONSUMER_CONFIG} found. Run blokos connect <url> first.` }))
+      } else {
+        console.error(chalk.red(`No ${CONSUMER_CONFIG} found. Run \`blokos connect <url>\` first.`))
+      }
+      process.exit(1)
+    }
+
+    const config: ConsumerConfig = await fs.readJson(configPath)
+    const lock = await readLockfile(cwd)
+    const forceRefresh = !opts.fetch
+
+    let found: ComponentDetail | null = null
+
+    for (const reg of config.registries) {
+      try {
+        const registry = await getOrFetchRegistry(cwd, reg, forceRefresh)
+        // Case-insensitive lookup
+        const comp: RegistryComponent | undefined =
+          registry.components[name] ??
+          Object.values(registry.components).find(
+            (c) => c.name.toLowerCase() === name.toLowerCase()
+          )
+
+        if (comp) {
+          const lockEntry = lock.components[comp.name]
+          found = {
+            name: comp.name,
+            category: comp.category,
+            description: comp.description,
+            version: registry.version,
+            files: comp.files,
+            dependencies: comp.dependencies,
+            examples: comp.examples,
+            schema: comp.schema,
+            installed: !!lockEntry,
+            installedVersion: lockEntry?.version,
+            registry: reg.name,
+          }
+          break
+        }
+      } catch (err) {
+        if (!opts.json) {
+          console.warn(chalk.yellow(`  Warning: could not fetch ${reg.name}: ${err}`))
+        }
+      }
+    }
+
+    if (!found) {
+      if (opts.json) {
+        console.log(JSON.stringify({ error: `Component "${name}" not found.` }))
+      } else {
+        console.error(chalk.red(`Component "${name}" not found in any connected registry.`))
+      }
+      process.exit(1)
+    }
+
+    if (opts.json) {
+      console.log(JSON.stringify(found, null, 2))
+      return
+    }
+
+    printDetail(found)
+  })

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -4,62 +4,101 @@ import ora from 'ora'
 import fs from 'fs-extra'
 import path from 'node:path'
 import { CONSUMER_CONFIG } from '../core/constants.js'
-import { fetchRegistry } from '../core/registry-fetcher.js'
+import { getOrFetchRegistry } from '../core/registry-cache.js'
+import { readLockfile } from '../core/lockfile.js'
 import type { ConsumerConfig } from '../core/types.js'
+
+interface OutputRow {
+  name: string
+  category: string
+  description: string
+  registry: string
+  version: string
+  installed: boolean
+  installedVersion: string | undefined
+}
 
 export const listCommand = new Command('list')
   .description('List available and installed components')
-  .action(async () => {
+  .option('--json', 'Output as JSON')
+  .option('--no-fetch', 'Skip remote refresh, use cached registry only')
+  .action(async (opts: { json?: boolean; fetch: boolean }) => {
     const cwd = process.cwd()
     const configPath = path.join(cwd, CONSUMER_CONFIG)
+    const isTTY = process.stdout.isTTY
 
     if (!(await fs.pathExists(configPath))) {
-      console.log(chalk.red(`No ${CONSUMER_CONFIG} found. Run \`blokos connect <url>\` first.`))
+      if (opts.json) {
+        console.log(JSON.stringify({ error: `No ${CONSUMER_CONFIG} found. Run blokos connect <url> first.` }))
+      } else {
+        console.log(chalk.red(`No ${CONSUMER_CONFIG} found. Run \`blokos connect <url>\` first.`))
+      }
       process.exit(1)
     }
 
     const config: ConsumerConfig = await fs.readJson(configPath)
 
     if (config.registries.length === 0) {
-      console.log(chalk.yellow('No registries connected.'))
+      if (opts.json) {
+        console.log(JSON.stringify([]))
+      } else {
+        console.log(chalk.yellow('No registries connected.'))
+      }
       return
     }
 
-    const spinner = ora('Fetching registries...').start()
+    const spinner = isTTY && !opts.json ? ora('Fetching registries...').start() : null
+    const lock = await readLockfile(cwd)
+    const forceRefresh = !opts.fetch
 
-    const installed = new Set(Object.keys(config.installed || {}))
-
-    const rows: Array<{
-      name: string
-      category: string
-      registry: string
-      status: string
-    }> = []
+    const rows: OutputRow[] = []
 
     for (const reg of config.registries) {
       try {
-        const registry = await fetchRegistry(reg.url, reg.token)
+        const registry = await getOrFetchRegistry(cwd, reg, forceRefresh)
         for (const comp of Object.values(registry.components)) {
+          const lockEntry = lock.components[comp.name]
           rows.push({
             name: comp.name,
             category: comp.category,
+            description: comp.description,
             registry: reg.name,
-            status: installed.has(comp.name) ? 'installed' : 'available',
+            version: registry.version,
+            installed: !!lockEntry,
+            installedVersion: lockEntry?.version,
           })
         }
       } catch (err) {
-        console.warn(`  Warning: could not fetch ${reg.name}: ${err}`)
+        if (!opts.json) {
+          console.warn(`  Warning: could not fetch ${reg.name}: ${err}`)
+        }
       }
     }
 
-    spinner.stop()
+    if (spinner) spinner.stop()
 
-    if (rows.length === 0) {
-      console.log(chalk.yellow('No components found in connected registries.'))
+    if (opts.json) {
+      console.log(JSON.stringify(rows, null, 2))
       return
     }
 
-    // Print table
+    if (rows.length === 0) {
+      if (isTTY) {
+        console.log(chalk.yellow('No components found in connected registries.'))
+      }
+      return
+    }
+
+    if (!isTTY) {
+      // Clean output for piped usage
+      for (const row of rows) {
+        const status = row.installed ? `v${row.installedVersion} installed` : '(not installed)'
+        console.log(`${row.name}\t${row.category}\t${row.registry}\t${status}`)
+      }
+      return
+    }
+
+    // TTY formatted table
     const nameWidth = Math.max(10, ...rows.map((r) => r.name.length)) + 2
     const catWidth = Math.max(10, ...rows.map((r) => r.category.length)) + 2
     const regWidth = Math.max(10, ...rows.map((r) => r.registry.length)) + 2
@@ -74,16 +113,18 @@ export const listCommand = new Command('list')
           'Status'
       )
     )
-    console.log('  ' + '─'.repeat(nameWidth + catWidth + regWidth + 12))
+    console.log('  ' + '─'.repeat(nameWidth + catWidth + regWidth + 20))
 
     for (const row of rows) {
-      const statusColor = row.status === 'installed' ? chalk.green : chalk.dim
+      const status = row.installed
+        ? chalk.green(`v${row.installedVersion} ✓ installed`)
+        : chalk.dim('(not installed)')
       console.log(
         '  ' +
           row.name.padEnd(nameWidth) +
           row.category.padEnd(catWidth) +
           row.registry.padEnd(regWidth) +
-          statusColor(row.status)
+          status
       )
     }
 

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -1,0 +1,131 @@
+import { Command } from 'commander'
+import chalk from 'chalk'
+import fs from 'fs-extra'
+import path from 'node:path'
+import { CONSUMER_CONFIG } from '../core/constants.js'
+import { getOrFetchRegistry } from '../core/registry-cache.js'
+import { searchComponents } from '../core/search.js'
+import { readLockfile } from '../core/lockfile.js'
+import type { ConsumerConfig, RegistryComponent } from '../core/types.js'
+
+interface OutputRow {
+  name: string
+  category: string
+  description: string
+  version: string
+  installed: boolean
+  installedVersion: string | undefined
+}
+
+function buildRow(
+  comp: RegistryComponent,
+  registryVersion: string,
+  lockComponents: Record<string, { version: string }>
+): OutputRow {
+  const lockEntry = lockComponents[comp.name]
+  return {
+    name: comp.name,
+    category: comp.category,
+    description: comp.description,
+    version: registryVersion,
+    installed: !!lockEntry,
+    installedVersion: lockEntry?.version,
+  }
+}
+
+function printRows(rows: OutputRow[]): void {
+  if (rows.length === 0) {
+    console.log('No components found.')
+    return
+  }
+
+  const isTTY = process.stdout.isTTY
+
+  if (!isTTY) {
+    // Clean output for piped usage
+    for (const row of rows) {
+      const status = row.installed ? `v${row.installedVersion} installed` : '(not installed)'
+      console.log(`${row.name}\t${row.category}\t${row.description}\t${status}`)
+    }
+    return
+  }
+
+  const nameWidth = Math.max(10, ...rows.map((r) => r.name.length)) + 2
+  const catWidth = Math.max(10, ...rows.map((r) => r.category.length)) + 2
+  const descWidth = Math.max(20, ...rows.map((r) => r.description.length)) + 2
+
+  console.log('')
+  console.log(
+    chalk.bold(
+      '  ' +
+        'Name'.padEnd(nameWidth) +
+        'Category'.padEnd(catWidth) +
+        'Description'.padEnd(descWidth) +
+        'Status'
+    )
+  )
+  console.log('  ' + '─'.repeat(nameWidth + catWidth + descWidth + 20))
+
+  for (const row of rows) {
+    const status = row.installed
+      ? chalk.green(`v${row.installedVersion} ✓ installed`)
+      : chalk.dim('(not installed)')
+    console.log(
+      '  ' +
+        chalk.cyan(row.name.padEnd(nameWidth)) +
+        row.category.padEnd(catWidth) +
+        row.description.padEnd(descWidth) +
+        status
+    )
+  }
+
+  console.log('')
+}
+
+export const searchCommand = new Command('search')
+  .description('Search for components by name, description, or category')
+  .argument('<query>', 'Search query')
+  .option('--json', 'Output as JSON')
+  .option('--no-fetch', 'Skip remote refresh, use cached registry only')
+  .action(async (query: string, opts: { json?: boolean; fetch: boolean }) => {
+    const cwd = process.cwd()
+    const configPath = path.join(cwd, CONSUMER_CONFIG)
+
+    if (!(await fs.pathExists(configPath))) {
+      if (opts.json) {
+        console.log(JSON.stringify({ error: `No ${CONSUMER_CONFIG} found. Run blokos connect <url> first.` }))
+      } else {
+        console.error(chalk.red(`No ${CONSUMER_CONFIG} found. Run \`blokos connect <url>\` first.`))
+      }
+      process.exit(1)
+    }
+
+    const config: ConsumerConfig = await fs.readJson(configPath)
+    const lock = await readLockfile(cwd)
+    const forceRefresh = !opts.fetch
+
+    const rows: OutputRow[] = []
+
+    for (const reg of config.registries) {
+      try {
+        const registry = await getOrFetchRegistry(cwd, reg, forceRefresh)
+        const matches = searchComponents(registry.components, query)
+        for (const comp of matches) {
+          rows.push(buildRow(comp, registry.version, lock.components))
+        }
+      } catch (err) {
+        if (!opts.json) {
+          console.warn(chalk.yellow(`  Warning: could not fetch ${reg.name}: ${err}`))
+        }
+      }
+    }
+
+    if (opts.json || !process.stdout.isTTY) {
+      if (opts.json) {
+        console.log(JSON.stringify(rows, null, 2))
+        return
+      }
+    }
+
+    printRows(rows)
+  })

--- a/src/commands/suggest.ts
+++ b/src/commands/suggest.ts
@@ -1,0 +1,132 @@
+import { Command } from 'commander'
+import chalk from 'chalk'
+import fs from 'fs-extra'
+import path from 'node:path'
+import { CONSUMER_CONFIG } from '../core/constants.js'
+import { getOrFetchRegistry } from '../core/registry-cache.js'
+import { suggestComponents } from '../core/search.js'
+import { readLockfile } from '../core/lockfile.js'
+import type { ConsumerConfig, RegistryComponent } from '../core/types.js'
+
+interface OutputRow {
+  name: string
+  category: string
+  description: string
+  version: string
+  installed: boolean
+  installedVersion: string | undefined
+}
+
+function buildRow(
+  comp: RegistryComponent,
+  registryVersion: string,
+  lockComponents: Record<string, { version: string }>
+): OutputRow {
+  const lockEntry = lockComponents[comp.name]
+  return {
+    name: comp.name,
+    category: comp.category,
+    description: comp.description,
+    version: registryVersion,
+    installed: !!lockEntry,
+    installedVersion: lockEntry?.version,
+  }
+}
+
+function printRows(rows: OutputRow[]): void {
+  if (rows.length === 0) {
+    console.log('No suggestions found.')
+    return
+  }
+
+  const isTTY = process.stdout.isTTY
+
+  if (!isTTY) {
+    for (const row of rows) {
+      const status = row.installed ? `v${row.installedVersion} installed` : '(not installed)'
+      console.log(`${row.name}\t${row.category}\t${row.description}\t${status}`)
+    }
+    return
+  }
+
+  const nameWidth = Math.max(10, ...rows.map((r) => r.name.length)) + 2
+  const catWidth = Math.max(10, ...rows.map((r) => r.category.length)) + 2
+  const descWidth = Math.max(20, ...rows.map((r) => r.description.length)) + 2
+
+  console.log('')
+  console.log(
+    chalk.bold(
+      '  ' +
+        'Name'.padEnd(nameWidth) +
+        'Category'.padEnd(catWidth) +
+        'Description'.padEnd(descWidth) +
+        'Status'
+    )
+  )
+  console.log('  ' + '─'.repeat(nameWidth + catWidth + descWidth + 20))
+
+  for (const row of rows) {
+    const status = row.installed
+      ? chalk.green(`v${row.installedVersion} ✓ installed`)
+      : chalk.dim('(not installed)')
+    console.log(
+      '  ' +
+        chalk.cyan(row.name.padEnd(nameWidth)) +
+        row.category.padEnd(catWidth) +
+        row.description.padEnd(descWidth) +
+        status
+    )
+  }
+
+  console.log('')
+}
+
+export const suggestCommand = new Command('suggest')
+  .description('Suggest components based on a natural language phrase (tokenized search)')
+  .argument('<phrase>', 'Natural language phrase')
+  .option('--json', 'Output as JSON')
+  .option('--no-fetch', 'Skip remote refresh, use cached registry only')
+  .action(async (phrase: string, opts: { json?: boolean; fetch: boolean }) => {
+    const cwd = process.cwd()
+    const configPath = path.join(cwd, CONSUMER_CONFIG)
+
+    if (!(await fs.pathExists(configPath))) {
+      if (opts.json) {
+        console.log(JSON.stringify({ error: `No ${CONSUMER_CONFIG} found. Run blokos connect <url> first.` }))
+      } else {
+        console.error(chalk.red(`No ${CONSUMER_CONFIG} found. Run \`blokos connect <url>\` first.`))
+      }
+      process.exit(1)
+    }
+
+    const config: ConsumerConfig = await fs.readJson(configPath)
+    const lock = await readLockfile(cwd)
+    const forceRefresh = !opts.fetch
+
+    const seen = new Set<string>()
+    const rows: OutputRow[] = []
+
+    for (const reg of config.registries) {
+      try {
+        const registry = await getOrFetchRegistry(cwd, reg, forceRefresh)
+        const matches = suggestComponents(registry.components, phrase)
+        for (const comp of matches) {
+          if (!seen.has(comp.name)) {
+            seen.add(comp.name)
+            rows.push(buildRow(comp, registry.version, lock.components))
+          }
+        }
+      } catch (err) {
+        if (!opts.json) {
+          console.warn(chalk.yellow(`  Warning: could not fetch ${reg.name}: ${err}`))
+        }
+      }
+    }
+
+    if (opts.json) {
+      console.log(JSON.stringify(rows, null, 2))
+      return
+    }
+
+    printRows(rows)
+  })

--- a/src/core/registry-cache.test.ts
+++ b/src/core/registry-cache.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import fs from 'fs-extra'
+import path from 'node:path'
+import os from 'node:os'
+import {
+  getCachedRegistry,
+  setCachedRegistry,
+  isCacheStale,
+  getOrFetchRegistry,
+  DEFAULT_TTL_MS,
+} from './registry-cache.js'
+import type { RegistryJson, RegistryEntry } from './types.js'
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'blokos-cache-test-'))
+}
+
+const sampleRegistry: RegistryJson = {
+  name: 'test-registry',
+  version: '1.0.0',
+  description: 'A test registry',
+  framework: 'react',
+  components: {
+    Button: {
+      name: 'Button',
+      description: 'A button',
+      category: 'atom',
+      files: ['button.tsx'],
+      schema: {},
+      dependencies: [],
+      examples: [],
+    },
+  },
+}
+
+describe('getCachedRegistry', () => {
+  it('returns null when cache file does not exist', async () => {
+    const cwd = makeTmpDir()
+    const result = await getCachedRegistry(cwd, 'test-registry')
+    expect(result).toBeNull()
+    await fs.remove(cwd)
+  })
+
+  it('returns cached data when file exists', async () => {
+    const cwd = makeTmpDir()
+    await setCachedRegistry(cwd, 'test-registry', sampleRegistry)
+    const result = await getCachedRegistry(cwd, 'test-registry')
+    expect(result).not.toBeNull()
+    expect(result?.registry).toEqual(sampleRegistry)
+    await fs.remove(cwd)
+  })
+
+  it('returns null when cache file is malformed JSON', async () => {
+    const cwd = makeTmpDir()
+    await fs.ensureDir(path.join(cwd, '.blokos/cache'))
+    await fs.writeFile(path.join(cwd, '.blokos/cache/bad-registry.json'), '{not valid json')
+    const result = await getCachedRegistry(cwd, 'bad-registry')
+    expect(result).toBeNull()
+    await fs.remove(cwd)
+  })
+})
+
+describe('setCachedRegistry', () => {
+  it('writes cache file with fetchedAt timestamp', async () => {
+    const cwd = makeTmpDir()
+    await setCachedRegistry(cwd, 'my-reg', sampleRegistry)
+    const cacheFile = path.join(cwd, '.blokos/cache/my-reg.json')
+    expect(await fs.pathExists(cacheFile)).toBe(true)
+    const data = await fs.readJson(cacheFile)
+    expect(data.registry).toEqual(sampleRegistry)
+    expect(typeof data.fetchedAt).toBe('string')
+    expect(new Date(data.fetchedAt).getTime()).toBeGreaterThan(0)
+    await fs.remove(cwd)
+  })
+})
+
+describe('isCacheStale', () => {
+  it('returns false when cache is fresh', () => {
+    const recentTimestamp = new Date(Date.now() - 10_000).toISOString() // 10 seconds ago
+    expect(isCacheStale(recentTimestamp, DEFAULT_TTL_MS)).toBe(false)
+  })
+
+  it('returns true when cache is older than TTL', () => {
+    const oldTimestamp = new Date(Date.now() - DEFAULT_TTL_MS - 1000).toISOString()
+    expect(isCacheStale(oldTimestamp, DEFAULT_TTL_MS)).toBe(true)
+  })
+
+  it('uses default TTL of 1 hour', () => {
+    const justUnder1h = new Date(Date.now() - 59 * 60 * 1000).toISOString()
+    expect(isCacheStale(justUnder1h)).toBe(false)
+
+    const justOver1h = new Date(Date.now() - 61 * 60 * 1000).toISOString()
+    expect(isCacheStale(justOver1h)).toBe(true)
+  })
+})
+
+describe('getOrFetchRegistry', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns cached registry when cache is fresh', async () => {
+    const cwd = makeTmpDir()
+    await setCachedRegistry(cwd, 'test-registry', sampleRegistry)
+
+    // Spy on fetchRegistry — should NOT be called
+    const { fetchRegistry } = await import('./registry-fetcher.js')
+    const fetchSpy = vi.spyOn({ fetchRegistry }, 'fetchRegistry')
+
+    const entry: RegistryEntry = { name: 'test-registry', url: 'https://example.com' }
+    const result = await getOrFetchRegistry(cwd, entry)
+    expect(result).toEqual(sampleRegistry)
+
+    fetchSpy.mockRestore()
+    await fs.remove(cwd)
+  })
+
+  it('fetches and caches when cache is stale', async () => {
+    const cwd = makeTmpDir()
+
+    // Write a stale cache (2h ago)
+    const staleCache = {
+      fetchedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+      registry: { ...sampleRegistry, version: '0.0.1' },
+    }
+    await fs.ensureDir(path.join(cwd, '.blokos/cache'))
+    await fs.writeJson(path.join(cwd, '.blokos/cache/test-registry.json'), staleCache)
+
+    // Mock fetchRegistry
+    const fetcherModule = await import('./registry-fetcher.js')
+    vi.spyOn(fetcherModule, 'fetchRegistry').mockResolvedValue(sampleRegistry)
+
+    const entry: RegistryEntry = { name: 'test-registry', url: 'https://example.com' }
+    const result = await getOrFetchRegistry(cwd, entry)
+    expect(result.version).toBe('1.0.0')
+
+    // Verify new cache was written
+    const cached = await getCachedRegistry(cwd, 'test-registry')
+    expect(cached?.registry.version).toBe('1.0.0')
+
+    vi.restoreAllMocks()
+    await fs.remove(cwd)
+  })
+
+  it('fetches when forceRefresh is true even if cache is fresh', async () => {
+    const cwd = makeTmpDir()
+    await setCachedRegistry(cwd, 'test-registry', { ...sampleRegistry, version: '0.5.0' })
+
+    const fetcherModule = await import('./registry-fetcher.js')
+    vi.spyOn(fetcherModule, 'fetchRegistry').mockResolvedValue(sampleRegistry)
+
+    const entry: RegistryEntry = { name: 'test-registry', url: 'https://example.com' }
+    const result = await getOrFetchRegistry(cwd, entry, true)
+    expect(result.version).toBe('1.0.0')
+
+    vi.restoreAllMocks()
+    await fs.remove(cwd)
+  })
+})

--- a/src/core/registry-cache.ts
+++ b/src/core/registry-cache.ts
@@ -1,0 +1,66 @@
+import fs from 'fs-extra'
+import path from 'node:path'
+import { fetchRegistry } from './registry-fetcher.js'
+import type { RegistryJson, RegistryEntry } from './types.js'
+
+export interface CachedRegistry {
+  fetchedAt: string // ISO timestamp
+  registry: RegistryJson
+}
+
+const CACHE_DIR = '.blokos/cache'
+export const DEFAULT_TTL_MS = 60 * 60 * 1000 // 1 hour
+
+function cachePath(cwd: string, registryName: string): string {
+  return path.join(cwd, CACHE_DIR, `${registryName}.json`)
+}
+
+export async function getCachedRegistry(
+  cwd: string,
+  registryName: string
+): Promise<CachedRegistry | null> {
+  const file = cachePath(cwd, registryName)
+  if (!(await fs.pathExists(file))) return null
+  try {
+    return (await fs.readJson(file)) as CachedRegistry
+  } catch {
+    return null
+  }
+}
+
+export async function setCachedRegistry(
+  cwd: string,
+  registryName: string,
+  registry: RegistryJson
+): Promise<void> {
+  const file = cachePath(cwd, registryName)
+  await fs.ensureDir(path.dirname(file))
+  const cached: CachedRegistry = {
+    fetchedAt: new Date().toISOString(),
+    registry,
+  }
+  await fs.writeJson(file, cached, { spaces: 2 })
+}
+
+export function isCacheStale(cachedAt: string, ttlMs: number = DEFAULT_TTL_MS): boolean {
+  const age = Date.now() - new Date(cachedAt).getTime()
+  return age > ttlMs
+}
+
+export async function getOrFetchRegistry(
+  cwd: string,
+  entry: RegistryEntry,
+  forceRefresh = false
+): Promise<RegistryJson> {
+  if (!forceRefresh) {
+    const cached = await getCachedRegistry(cwd, entry.name)
+    if (cached && !isCacheStale(cached.fetchedAt)) {
+      return cached.registry
+    }
+  }
+
+  const token = process.env[`BLOKOS_TOKEN_${entry.name.toUpperCase().replace(/[^A-Z0-9]/g, '_')}`]
+  const registry = await fetchRegistry(entry.url, token)
+  await setCachedRegistry(cwd, entry.name, registry)
+  return registry
+}

--- a/src/core/search.test.ts
+++ b/src/core/search.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { searchComponents, suggestComponents } from './search.js'
+import type { RegistryComponent } from './types.js'
+
+function makeComponent(overrides: Partial<RegistryComponent> & { name: string }): RegistryComponent {
+  return {
+    name: overrides.name,
+    description: overrides.description ?? '',
+    category: overrides.category ?? 'atom',
+    files: overrides.files ?? [],
+    schema: overrides.schema ?? {},
+    dependencies: overrides.dependencies ?? [],
+    examples: overrides.examples ?? [],
+  }
+}
+
+const components: Record<string, RegistryComponent> = {
+  Button: makeComponent({ name: 'Button', description: 'A clickable button', category: 'atom' }),
+  HeroSection: makeComponent({ name: 'HeroSection', description: 'Full-width hero section', category: 'organism' }),
+  DataTable: makeComponent({ name: 'DataTable', description: 'Table with sorting and filtering', category: 'molecule' }),
+  PricingCard: makeComponent({ name: 'PricingCard', description: 'Pricing plan card', category: 'molecule' }),
+  NavBar: makeComponent({ name: 'NavBar', description: 'Top navigation bar', category: 'organism' }),
+}
+
+describe('searchComponents', () => {
+  it('matches by name (partial, case-insensitive)', () => {
+    const results = searchComponents(components, 'button')
+    expect(results.map((r) => r.name)).toContain('Button')
+  })
+
+  it('matches by description', () => {
+    const results = searchComponents(components, 'sorting')
+    expect(results.map((r) => r.name)).toContain('DataTable')
+  })
+
+  it('matches by category', () => {
+    const results = searchComponents(components, 'organism')
+    const names = results.map((r) => r.name)
+    expect(names).toContain('HeroSection')
+    expect(names).toContain('NavBar')
+  })
+
+  it('returns empty array when nothing matches', () => {
+    const results = searchComponents(components, 'nonexistent-xyz')
+    expect(results).toEqual([])
+  })
+
+  it('is case-insensitive', () => {
+    const results = searchComponents(components, 'PRICING')
+    expect(results.map((r) => r.name)).toContain('PricingCard')
+  })
+
+  it('matches partial name', () => {
+    const results = searchComponents(components, 'hero')
+    expect(results.map((r) => r.name)).toContain('HeroSection')
+  })
+
+  it('returns all components when query is an empty string (matches everything)', () => {
+    const results = searchComponents(components, '')
+    expect(results.length).toBe(Object.keys(components).length)
+  })
+})
+
+describe('suggestComponents', () => {
+  it('tokenizes phrase and matches each token', () => {
+    const results = suggestComponents(components, 'table with sorting')
+    expect(results.map((r) => r.name)).toContain('DataTable')
+  })
+
+  it('returns results from multiple tokens (OR logic)', () => {
+    const results = suggestComponents(components, 'button hero')
+    const names = results.map((r) => r.name)
+    expect(names).toContain('Button')
+    expect(names).toContain('HeroSection')
+  })
+
+  it('deduplicates results', () => {
+    // "nav" matches NavBar once; make sure it only appears once
+    const results = suggestComponents(components, 'nav bar navigation')
+    const navBars = results.filter((r) => r.name === 'NavBar')
+    expect(navBars.length).toBe(1)
+  })
+
+  it('returns empty array for empty phrase', () => {
+    const results = suggestComponents(components, '')
+    expect(results).toEqual([])
+  })
+
+  it('returns empty array for whitespace-only phrase', () => {
+    const results = suggestComponents(components, '   ')
+    expect(results).toEqual([])
+  })
+
+  it('ignores tokens that do not match anything', () => {
+    const results = suggestComponents(components, 'nonexistent button')
+    expect(results.map((r) => r.name)).toContain('Button')
+  })
+})

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -1,0 +1,49 @@
+import type { RegistryComponent } from './types.js'
+
+/**
+ * Returns components matching the query — partial, case-insensitive match
+ * on name, description, or category.
+ */
+export function searchComponents(
+  components: Record<string, RegistryComponent>,
+  query: string
+): RegistryComponent[] {
+  const q = query.toLowerCase()
+  return Object.values(components).filter((comp) => {
+    return (
+      comp.name.toLowerCase().includes(q) ||
+      comp.description.toLowerCase().includes(q) ||
+      comp.category.toLowerCase().includes(q)
+    )
+  })
+}
+
+/**
+ * Tokenizes phrase and searches each token (OR logic).
+ * Deduplicates results by component name.
+ */
+export function suggestComponents(
+  components: Record<string, RegistryComponent>,
+  phrase: string
+): RegistryComponent[] {
+  const tokens = phrase
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((t) => t.length > 0)
+
+  if (tokens.length === 0) return []
+
+  const seen = new Set<string>()
+  const results: RegistryComponent[] = []
+
+  for (const token of tokens) {
+    for (const comp of searchComponents(components, token)) {
+      if (!seen.has(comp.name)) {
+        seen.add(comp.name)
+        results.push(comp)
+      }
+    }
+  }
+
+  return results
+}


### PR DESCRIPTION
Closes #7

## Summary

- **`src/core/registry-cache.ts`** — Local registry cache with 1h TTL. `getOrFetchRegistry` returns cached data if fresh, fetches + caches if stale. `--no-fetch` flag forces offline mode.
- **`src/core/search.ts`** — `searchComponents` (partial match on name/description/category) and `suggestComponents` (tokenized phrase → OR-logic search with dedup).
- **`src/commands/search.ts`** — `blokos search <query> [--json] [--no-fetch]`
- **`src/commands/get.ts`** — `blokos get <name> [--json] [--no-fetch]` — full component details: props table, examples, dependencies, installed version from `blokos.lock`
- **`src/commands/suggest.ts`** — `blokos suggest <phrase> [--json] [--no-fetch]`
- **`src/commands/list.ts`** — Updated: `--json` flag added, installed version shown from `blokos.lock`, TTY-aware output
- **`src/cli.ts`** — Registers `search`, `get`, `suggest` commands

All commands detect `process.stdout.isTTY` — clean tab-separated output when piped, chalk/ANSI formatting in a terminal. `--json` outputs a structured JSON array suitable for AI agent consumption.

## Test plan

- [ ] npm test — 81 tests pass (23 new: 10 cache + 13 search)
- [ ] npm run build — TypeScript compiles cleanly
- [ ] blokos search "button" — returns matching components in TTY format
- [ ] blokos search "button" --json — returns JSON array
- [ ] blokos get Button — shows full detail with props table and installed status
- [ ] blokos suggest "table with sorting" — tokenizes phrase and returns DataTable etc.
- [ ] blokos list --json — returns structured JSON with installed versions
- [ ] blokos search "button" --no-fetch — uses cached registry, no network call

Generated with Claude Code
